### PR TITLE
[MSKINS-168] Switch Minification Engine from YUI to CLOSURE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@ under the License.
                 <jsSourceFile>fluido.js</jsSourceFile>
               </jsSourceFiles>
               <jsFinalFile>apache-maven-fluido-${project.version}.js</jsFinalFile>
+              <jsEngine>CLOSURE</jsEngine>
             </configuration>
             <goals>
               <goal>minify</goal>


### PR DESCRIPTION
YUI compressor engine seems not support ES5 syntaxes.
Js compilation fails when using new javascript libraries with ES5 syntax.

Switch to CLOSURE engine to bypass the issues.

Closes #168