### PR TITLE
[MSKINS-101] Remove decorationModel/custom/publishDate from skin-macr…

### DIFF
--- a/src/it/mskins-17/pom.xml
+++ b/src/it/mskins-17/pom.xml
@@ -37,6 +37,9 @@
     <skinGroupId>@project.groupId@</skinGroupId>
     <skinArtifactId>@project.artifactId@</skinArtifactId>
     <skinVersion>@project.version@</skinVersion>
+    <!-- START SNIPPET: skin-custom-config -->
+    <project.build.outputTimestamp>1990-01-01T00:00:00Z</project.build.outputTimestamp>
+    <!-- END SNIPPET: skin-custom-config -->
   </properties>
 
   <build>

--- a/src/it/mskins-17/src/site/apt/index.apt.vm
+++ b/src/it/mskins-17/src/site/apt/index.apt.vm
@@ -33,4 +33,4 @@ ${project.name}
 
 * Actual configuration
 
-%{snippet|id=skin-custom-config|file=${project.basedir}/src/site/site.xml}
+%{snippet|id=skin-custom-config|file=${project.basedir}/pom.xml}

--- a/src/it/mskins-17/src/site/site.xml
+++ b/src/it/mskins-17/src/site/site.xml
@@ -31,12 +31,6 @@
     <version>${skinVersion}</version>
   </skin>
 
-  <!-- START SNIPPET: skin-custom-config -->
-  <custom>
-    <publishDate>1970-01-01</publishDate>
-  </custom>
-  <!-- END SNIPPET: skin-custom-config -->
-
   <publishDate format="yyyy-MM-dd" position="right" />
 
   <body>

--- a/src/it/mskins-17/verify.groovy
+++ b/src/it/mskins-17/verify.groovy
@@ -19,4 +19,4 @@
 
 File index = new File( basedir, "target/site/index.html" )
 assert index.exists()
-assert index.text.contains( '<li id="publishDate" class="pull-right"><span class="divider">|</span> Last Published: 1970-01-01</li>' )
+assert index.text.contains( '<li id="publishDate" class="pull-right"><span class="divider">|</span> Last Published: 1990-01-01</li>' )

--- a/src/main/resources/META-INF/maven/site-macros.vm
+++ b/src/main/resources/META-INF/maven/site-macros.vm
@@ -410,8 +410,6 @@ $indent     </ul>##
 #macro ( publishDate $position $decorationPublishDate $version )
 #**##if ( $publishDate )
 #*  *##set ( $dateValue = $date.format( $publishDate ) )
-#**##elseif ( $decoration.custom.getChild( 'publishDate' ) )
-#*  *##set ( $dateValue = $decoration.custom.getChild( 'publishDate' ).getValue() )
 #**##else
 #*  *##set ( $dateValue = $date )
 #**##end


### PR DESCRIPTION
…os.vm

This can fully be replaced with MSITE-921. IF this custom value should be retained, I'd recommend to evaluate it *before* `$customDate` otherwise in reproducible builds it will be always set.